### PR TITLE
🎨 Implement green theme and fix profile image styling

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -39,7 +39,7 @@ const Hero = () => {
         <div className="max-w-4xl mx-auto">
           {/* Profile Image */}
           <div className="mb-8">
-            <div className="w-38 h-38 md:w-48 md:h-48 mx-auto rounded-full overflow-hidden shadow-2xl ring-4 ring-blue-500/20 hover:ring-blue-500/40 transition-all duration-300 hover:scale-105">
+            <div className="w-56 h-56 md:w-72 md:h-72 mx-auto rounded-lg overflow-hidden shadow-2xl ring-4 ring-primary/20 hover:ring-primary/40 transition-all duration-300 hover:scale-105">
               <img
                 src="/lovable-uploads/82867db7-4170-4c1c-8a97-0e35519bc2cb.png"
                 alt="Abhinay Gedela"

--- a/src/index.css
+++ b/src/index.css
@@ -7,88 +7,88 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --foreground: 120 15% 15%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 120 15% 15%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover-foreground: 120 15% 15%;
 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+    --primary: 142 76% 36%;
+    --primary-foreground: 0 0% 98%;
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 120 20% 95%;
+    --secondary-foreground: 120 15% 15%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 120 20% 95%;
+    --muted-foreground: 120 8% 46%;
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 120 30% 90%;
+    --accent-foreground: 120 15% 15%;
 
     --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive-foreground: 0 0% 98%;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --border: 120 15% 85%;
+    --input: 120 15% 85%;
+    --ring: 142 76% 36%;
 
     --radius: 0.5rem;
 
-    --sidebar-background: 0 0% 98%;
+    --sidebar-background: 120 25% 97%;
 
-    --sidebar-foreground: 240 5.3% 26.1%;
+    --sidebar-foreground: 120 15% 25%;
 
-    --sidebar-primary: 240 5.9% 10%;
+    --sidebar-primary: 142 76% 36%;
 
     --sidebar-primary-foreground: 0 0% 98%;
 
-    --sidebar-accent: 240 4.8% 95.9%;
+    --sidebar-accent: 120 20% 92%;
 
-    --sidebar-accent-foreground: 240 5.9% 10%;
+    --sidebar-accent-foreground: 120 15% 15%;
 
-    --sidebar-border: 220 13% 91%;
+    --sidebar-border: 120 15% 88%;
 
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-ring: 142 76% 36%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
+    --background: 120 15% 8%;
+    --foreground: 120 20% 95%;
 
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
+    --card: 120 15% 10%;
+    --card-foreground: 120 20% 95%;
 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --popover: 120 15% 10%;
+    --popover-foreground: 120 20% 95%;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 142 76% 48%;
+    --primary-foreground: 120 15% 8%;
 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 120 12% 18%;
+    --secondary-foreground: 120 20% 95%;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 120 12% 18%;
+    --muted-foreground: 120 10% 65%;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 120 15% 22%;
+    --accent-foreground: 120 20% 95%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 50.6%;
+    --destructive-foreground: 0 0% 98%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --border: 120 12% 20%;
+    --input: 120 12% 20%;
+    --ring: 142 76% 48%;
+    --sidebar-background: 120 15% 12%;
+    --sidebar-foreground: 120 20% 90%;
+    --sidebar-primary: 142 76% 48%;
+    --sidebar-primary-foreground: 120 15% 8%;
+    --sidebar-accent: 120 12% 16%;
+    --sidebar-accent-foreground: 120 20% 90%;
+    --sidebar-border: 120 12% 16%;
+    --sidebar-ring: 142 76% 48%;
   }
 }
 


### PR DESCRIPTION
## Summary
This PR implements two key improvements requested in GitHub issues:

• **Green Theme Implementation** (#1) - Complete color scheme overhaul to emerald green
• **Profile Image Fixes** (#3) - Increased size and changed from circular to square shape

## Changes Made

### 🎨 Green Theme Implementation
- Updated all CSS custom properties in `src/index.css`
- Implemented emerald green primary colors (`hsl(142, 76%, 36%)` for light mode)
- Created matching dark theme with green tones
- All shadcn/ui components automatically inherit the new theme
- Maintained accessibility and proper contrast ratios

### 📐 Profile Image Improvements  
- **Size**: Increased from `38x38/48x48` to `56x56/72x72` pixels (significantly larger)
- **Shape**: Changed from `rounded-full` (circular) to `rounded-lg` (square with rounded corners)
- **Theme Integration**: Updated ring colors to use primary theme colors instead of hardcoded blue

## Technical Details
- Modified CSS custom properties for both `:root` and `.dark` selectors
- Updated Hero component styling in `src/components/Hero.tsx`
- All changes are backward compatible
- Build process completes successfully

## Test Plan
- [x] Development server runs without errors
- [x] Production build completes successfully  
- [x] Green theme applies to all components
- [x] Profile image displays with correct size and shape
- [x] Both light and dark modes work properly
- [x] Hover effects and transitions still function

## Screenshots
View the changes locally by running `npm run dev` and visiting `http://localhost:8082`

## Issues Fixed
- Closes #1 - Green theme implementation
- Closes #3 - Profile image size and shape changes

🤖 Generated with Claude Code